### PR TITLE
agg binary is now ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.o
 *~
 *.a
-agg 
+/agg
 version.h
 *.pico
 gmon.out


### PR DESCRIPTION
The binary does not appear to be ignored with the trailing space on my system.