### PR TITLE
v0.3.6

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+2016-05-04
+*added more sophisticated decomposition routine for complex substitutions (take from vt)
+*variant ID field is now stripped when importing samples
+
 2016-05-03
 *switched to htslib-1.4
 *fixed a small memory leak in agg ingest1

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ agg_ingest2.o: agg_ingest2.cpp agg.h
 	$(CXX) $(CFLAGS) $(CXX_FLAGS) -c $<  
 agg_ingest1.o: agg_ingest1.cpp agg_ingest1.h agg.h version.h
 	$(CXX) $(CFLAGS) $(CXX_FLAGS) -c $<
+needle.o: needle.cpp needle.h
+	$(CXX) $(CFLAGS) $(CXX_FLAGS) -c $<
 ##these files were taken from bcftools hence compiled as straight C
 filter.o: filter.c 
 	$(CC) $(CFLAGS) -c $<  
@@ -67,8 +69,8 @@ vcmp.o: vcmp.c
 regidx.o: regidx.c
 	$(CC) $(CFLAGS) -c $<  
 ##binary
-agg: agg.cpp  agg_anno.o depthMerger.o vcfnorm.o vcmp.o vcfmerge.o  agg_ingest2.o utils.o agg_utils.o agg_genotyper.o  agg_ingest1.o version.o filter.o regidx.o version.h  $(HTSLIB)
-	$(CXX) $(CFLAGS)  -o agg agg.cpp regidx.o vcfnorm.o vcmp.o vcfmerge.o agg_ingest2.o agg_genotyper.o utils.o agg_utils.o  agg_ingest1.o depthMerger.o version.o agg_anno.o filter.o $(HTSLIB) $(LFLAGS) 
+agg: agg.cpp  agg_anno.o depthMerger.o vcfnorm.o vcmp.o vcfmerge.o  agg_ingest2.o utils.o agg_utils.o agg_genotyper.o  agg_ingest1.o version.o filter.o regidx.o needle.o version.h  $(HTSLIB)
+	$(CXX) $(CFLAGS)  -o agg agg.cpp regidx.o vcfnorm.o vcmp.o vcfmerge.o agg_ingest2.o agg_genotyper.o utils.o agg_utils.o  agg_ingest1.o depthMerger.o version.o agg_anno.o filter.o needle.o $(HTSLIB) $(LFLAGS) 
 test: agg
 	cd test/;bash -e test.sh 
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: agg plugins
 
 CFLAGS = -O2  $(ALLFLAGS) 
 
-debug: CFLAGS =  -pg -g -Wall $(ALLFLAGS) 
+debug: CFLAGS =  -O0 -pg -g -Wall $(ALLFLAGS) 
 debug: all 
 
 #linker stuff

--- a/agg_ingest1.cpp
+++ b/agg_ingest1.cpp
@@ -1,18 +1,29 @@
 #include "agg_ingest1.h"
 //#define DEBUG
 
+//just a struct to count some things
+struct Counts
+{
+    int mnp,complex;
+};
+
 static void remove_hdr_lines(bcf_hdr_t *hdr, int type)
 {
     int i = 0, nrm = 0;
     while ( i<hdr->nhrec )
     {
-        if ( hdr->hrec[i]->type!=type ) { i++; continue; }
+        if ( hdr->hrec[i]->type!=type ) 
+	{ 
+	    i++; 
+	    continue; 
+	}
         bcf_hrec_t *hrec = hdr->hrec[i];
         if ( type==BCF_HL_FMT )
         {
             // everything except FORMAT/GT
             int id = bcf_hrec_find_key(hrec, "ID");
-            if ( id>=0 && !strcmp(hrec->vals[id],"GT") ) {
+            if ( id>=0 && !strcmp(hrec->vals[id],"GT") ) 
+	    {
 		i++; continue;
 	    }
         }
@@ -68,7 +79,8 @@ char *find_format(char *ptr,char *FORMAT)
 }
 
 //small class to buffer bcf1_t records and sort them as they are inserted.
-class VarBuffer {
+class VarBuffer 
+{
 public:
     VarBuffer(int w) {
 	_w = w;//window size (physical bp)
@@ -141,20 +153,145 @@ private:
     set <string> _seen; //list of seen variants at this position.
 };
 
+//vt triple structure
+struct Triple
+{
+    int pos_ref;
+    int pos_alt;
+    int len_ref;
+    int len_alt;
+
+    Triple() : pos_ref(0), pos_alt(0), len_ref(0), len_alt(0)
+    {}
+
+    Triple(int pos_ref, int pos_alt, int len_ref, int len_alt) : pos_ref(pos_ref), pos_alt(pos_alt), len_ref(len_ref), len_alt(len_alt)
+    {}
+};
+
+//this is a (slightly) modfified version of vt's aggressive decompose 
+//see https://github.com/atks/vt
+int vt_aggressive_decompose(bcf1_t *v,bcf_hdr_t *hdr,VarBuffer & buf)
+{
+
+    int32_t n_allele = bcf_get_n_allele(v);
+    char** allele = bcf_get_allele(v);
+
+    size_t ref_len = strlen(allele[0]);
+    size_t alt_len = n_allele==1 ? 0 : strlen(allele[1]);
+
+    int new_no_variants=0;
+    kstring_t new_alleles= {0,0,0};
+    // Use alignment for decomposition of substitutions where REF
+    // and ALT have different lengths and the variant is not an
+    // insertion or deletion.
+    
+    // Perform alignment of REF[1:] and ALT[1:]
+    NeedlemanWunsch nw(true);
+    nw.align(allele[0] + 1, allele[1] + 1);
+    nw.trace_path();
+    // Force-align first characters
+    if (allele[0][0] == allele[1][0])
+	nw.trace.insert(nw.trace.begin(), NeedlemanWunsch::CIGAR_M);
+    else
+	nw.trace.insert(nw.trace.begin(), NeedlemanWunsch::CIGAR_X);
+    nw.read--;
+    nw.ref--;
+
+    // Break apart alignment
+    std::vector<Triple> chunks;
+    bool hasError = false;
+    int pos_ref = 0, pos_alt = 0, k = 0;
+    Triple nextChunk(pos_ref, pos_alt, 0, 0);
+    while (pos_ref <= nw.len_ref || pos_alt <= nw.len_read)
+    {
+	switch ((int32_t)nw.trace.at(k++))
+	{
+	case NeedlemanWunsch::CIGAR_M:
+	    if (hasError)
+		chunks.push_back(nextChunk);
+	    nextChunk = Triple(pos_ref++, pos_alt++, 1, 1);
+	    hasError = false;
+	    break;
+	case NeedlemanWunsch::CIGAR_X:
+	    if (hasError)
+		chunks.push_back(nextChunk);
+	    nextChunk = Triple(pos_ref++, pos_alt++, 1, 1);
+	    hasError = true;
+	    break;
+	case NeedlemanWunsch::CIGAR_D:
+	    nextChunk.len_ref++;
+	    pos_ref++;
+	    hasError = true;
+	    break;
+	case NeedlemanWunsch::CIGAR_I:
+	    nextChunk.len_alt++;
+	    pos_alt++;
+	    hasError = true;
+	    break;
+	}
+    }
+    if (hasError)
+	chunks.push_back(nextChunk);
+
+    // Build new BCF records.
+    int32_t rid = bcf_get_rid(v);
+    int32_t pos1 = bcf_get_pos1(v);
+//    char** allele = bcf_get_allele(v); 
+
+    char* ref = strdup(v->d.allele[0]);
+    char* alt = strdup(v->d.allele[1]);
+
+    // old_alleles.l = 0;
+    // bcf_variant2string(hdr, v, &old_alleles);
+
+    for (size_t i=0; i<chunks.size(); ++i)
+    {
+	bcf1_t *nv = bcf_dup(v);
+	bcf_unpack(nv, BCF_UN_ALL);
+	bcf_set_pos1(nv, pos1+chunks[i].pos_ref);
+	std::vector<int32_t> start_pos_of_phased_block;
+	int32_t no_samples = bcf_get_n_sample(v);
+                        
+	new_alleles.l=0;
+	for (int j=chunks[i].pos_ref; j<chunks[i].pos_ref+chunks[i].len_ref; ++j)
+	    kputc(ref[j], &new_alleles);
+	kputc(',', &new_alleles);
+	for (int j=chunks[i].pos_alt; j<chunks[i].pos_alt+chunks[i].len_alt; ++j)
+	    kputc(alt[j], &new_alleles);
+
+	bcf_update_alleles_str(hdr, nv, new_alleles.s);
+//	bcf_update_info_string(hdr, nv, "OLD_CLUMPED", old_alleles.s);
+                    
+	buf.push_back(nv);
+	kputc('\0', &new_alleles);
+
+	++new_no_variants;
+    }
+
+    free(ref);
+    free(alt);
+    
+    return(new_no_variants);
+}
 
 
-//decomposes MNPs into multiple records and pushes them into the buffer.
-int decompose(bcf1_t *rec,bcf_hdr_t *hdr,VarBuffer & buf) {
+//1. decompose MNPs/complex substitutions 
+//2. normalises the output using bcftools norm algorithm
+int atomise(bcf1_t *rec,bcf_hdr_t *hdr,VarBuffer & buf,Counts & counts)
+{
     assert(rec->n_allele  == 2);
     char *ref=rec->d.allele[0];
     char *alt=rec->d.allele[1];
-    int refl = strlen(ref);
-    int altl = strlen(alt);
+    int ref_len = strlen(ref);
+    int alt_len = strlen(alt);
     int n=0;
-    if(refl>1 && refl==altl) {//is MNP
+    if(ref_len>1 && ref_len==alt_len) //is MNP
+    {
 	char alleles[4] = "X,X";
-	for(int i=0;i<refl;i++) {
-	    if(ref[i]!=alt[i]) {//new SNP
+	for(int i=0;i<ref_len;i++) 
+	{
+	    if(ref[i]!=alt[i]) 
+	    {//new SNP
 		bcf1_t *new_var = bcf_dup(rec);
 		bcf_unpack(new_var, BCF_UN_ALL);
 		alleles[0]=ref[i];
@@ -164,18 +301,28 @@ int decompose(bcf1_t *rec,bcf_hdr_t *hdr,VarBuffer & buf) {
 		buf.push_back(new_var);
 		bcf_destroy1(new_var);		
 		n++;
+		counts.mnp++;
 	    }
 	}
     }
-    else {
+    else if((ref_len!=alt_len) && (ref_len!=1) && (alt_len>1)) //complex substitution
+    {
+	n=vt_aggressive_decompose(rec,hdr,buf)	;
+	counts.complex+=n;
+    }
+    else //variant already is atomic
+    {
 	buf.push_back(rec);    
     }  
     return(n);
 }
 
-int ingest1(const char *input,const char *output,char *ref,bool exit_on_mismatch=true) {
+int ingest1(const char *input,const char *output,char *ref,bool exit_on_mismatch=true) 
+{
     cerr << "Input: " << input << "\tOutput: "<<output<<endl;
-
+    Counts counts;
+    counts.mnp=0;
+    counts.complex=0;
     kstream_t *ks;
     kstring_t str = {0,0,0};    
     gzFile fp = gzopen(input, "r");
@@ -312,38 +459,46 @@ int ingest1(const char *input,const char *output,char *ref,bool exit_on_mismatch
 		norm_args->ntotal++;
 		vcf_parse(&str,hdr_in,bcf_rec);
 		//	cerr<<bcf_rec->rid<<":"<<bcf_rec->pos<<endl;
-		if(prev_rid!=bcf_rec->rid) 
+		if(prev_rid!=bcf_rec->rid)
+		{
 		    vbuf.flush(variant_fp,hdr_out);
+		}		 
 		else
-		    vbuf.flush(bcf_rec->pos,variant_fp,hdr_out);
+		{
+		    vbuf.flush(bcf_rec->pos,variant_fp,hdr_out);		    
+		}		    
 		prev_rid=bcf_rec->rid;
 		int32_t pass = bcf_has_filter(hdr_in, bcf_rec, ".");
 		bcf_update_format_int32(hdr_out,bcf_rec,"PF",&pass,1);
 		bcf_update_filter(hdr_out,bcf_rec,NULL,0);
+		bcf1_t **split_records=&bcf_rec;
+		int num_split_records=1;
 		if(bcf_rec->n_allele>2)
 		{//split multi-allelics (using vcfnorm.c from bcftools1.3
 		    norm_args->nsplit++;
-		    split_multiallelic_to_biallelics(norm_args,bcf_rec );
-		    for(int i=0;i<norm_args->ntmp_lines;i++){
-			remove_info(norm_args->tmp_lines[i]);
-			if(realign(norm_args,norm_args->tmp_lines[i]) != ERR_REF_MISMATCH)
-			    ndec+=decompose(norm_args->tmp_lines[i],hdr_out,vbuf);
-			else
-			    if(exit_on_mismatch)
-				die("vcf did not match the reference");
-			    else
-				norm_args->nskipped++;
-		    }
+		    split_multiallelic_to_biallelics(norm_args,bcf_rec);
+		    split_records=norm_args->tmp_lines;
+		    num_split_records=norm_args->ntmp_lines;
 		}
-		else {
-		    remove_info(bcf_rec);
-		    if( realign(norm_args,bcf_rec) !=  ERR_REF_MISMATCH)
-			ndec+=decompose(bcf_rec,hdr_out,vbuf);
-		    else
-			if(exit_on_mismatch)
-			    die("vcf did not match the reference");
-			else
-			    norm_args->nskipped++;
+		for(int i=0;i<num_split_records;i++)
+		{
+		    remove_info(split_records[i]);
+		    vector<bcf1_t *> atomised_variants = atomise(split_records[i],hdr_out,counts);
+		    for(size_t j=0;j<atomised_variants.size(),j++)
+		    {
+			if(realign(norm_args,atomised_variants[j]) == ERR_REF_MISMATCH)
+			{
+			    if(exit_on_mismatch)
+			    {
+				die("vcf did not match the reference");
+			    }
+			    else
+			    {
+				norm_args->nskipped++;
+			    }			    
+			}
+			vbuf.push_back(atomised_variants[j]);
+		    }
 		}
 		vbuf.flush(bcf_rec->pos,variant_fp,hdr_out);
 	    }
@@ -361,7 +516,8 @@ int ingest1(const char *input,const char *output,char *ref,bool exit_on_mismatch
     hts_close(variant_fp);
     destroy_data(norm_args);
     fprintf(stderr,"Variant lines   total/split/realigned/skipped:\t%d/%d/%d/%d\n", norm_args->ntotal,norm_args->nsplit,norm_args->nchanged,norm_args->nskipped);
-    fprintf(stderr,"Decomposed %d MNPs\n", ndec);
+    fprintf(stderr,"Decomposed %d MNPs\n", counts.mnp);
+    fprintf(stderr,"Decomposed %d complex substitutions\n", counts.complex);
 
 
     fprintf(stderr,"Indexing %s\n",out_fname);

--- a/agg_ingest1.cpp
+++ b/agg_ingest1.cpp
@@ -296,8 +296,8 @@ vector<bcf1_t *> atomise(bcf1_t *rec,bcf_hdr_t *hdr,Counts & counts)
 		new_var->pos+=i;
 		bcf_update_alleles_str(hdr, new_var, alleles);	
 		ret.push_back(new_var);
-		counts.mnp++;
 	    }
+	    counts.mnp++;	    
 	}
     }
     else if((ref_len!=alt_len) && (ref_len!=1) && (alt_len>1)) //complex substitution

--- a/agg_ingest1.h
+++ b/agg_ingest1.h
@@ -7,6 +7,8 @@
 #include <locale>         // std::locale, std::toupper
 #include <algorithm>
 #include <iostream>
+#include "needle.h"
+#include "hts_utils.h"
 
 KSTREAM_INIT(gzFile, gzread, 16384)
 

--- a/agg_ingest2.cpp
+++ b/agg_ingest2.cpp
@@ -114,11 +114,11 @@ int merge_main(int argc,char **argv) {
       vcfmerge_argc++;
   }
 
-  // cerr<<"bcftools merge argv: ";
-  // for(int i=0;i<vcfmerge_argc;i++)
-  // {
-  //     cerr<<" "<< vcfmerge_argv[i];
-  // }
+  cerr<<"bcftools merge argv: ";
+  for(int i=0;i<vcfmerge_argc;i++)
+  {
+      cerr<<" "<< vcfmerge_argv[i];
+  }
 
   cerr<<endl;
   optind=0;//reset getopt

--- a/agg_ingest2.cpp
+++ b/agg_ingest2.cpp
@@ -105,7 +105,7 @@ int merge_main(int argc,char **argv) {
   vcfmerge_argv[vcfmerge_argc++]="-";
   vcfmerge_argv[vcfmerge_argc++]="--threads";
   vcfmerge_argv[vcfmerge_argc]=new char[10];
-  snprintf(vcfmerge_argv[vcfmerge_argc++], 10, "%d", n_threads);
+  snprintf(vcfmerge_argv[vcfmerge_argc++], 10, "%d", min(2,n_threads));//limit the number of threads to 2 here. >2 does not seem to improve speed
 
   for(size_t i=0;i<file_list.size();i++)
   {

--- a/agg_ingest2.cpp
+++ b/agg_ingest2.cpp
@@ -125,7 +125,7 @@ int merge_main(int argc,char **argv) {
   main_vcfmerge(vcfmerge_argc, vcfmerge_argv);  
   output_bcf=(char *)malloc(strlen(output)+5);  strcat(strcpy(output_bcf,output),".bcf");
   cerr << "Indexing " <<output_bcf<<endl;
-  bcf_index_build(output_bcf, BCF_LIDX_SHIFT);
+  bcf_index_build3(output_bcf,NULL, BCF_LIDX_SHIFT,n_threads);
 
   ///build the depth tract - custom agg code
   char *dp_out_fname=(char *)malloc(strlen(output)+5);
@@ -134,7 +134,6 @@ int merge_main(int argc,char **argv) {
   d.setThreads(n_threads);
   d.writeDepthMatrix(dp_out_fname);
   cerr << "Indexing " <<dp_out_fname<<endl;
-  bcf_index_build(dp_out_fname, BCF_LIDX_SHIFT);
-
+  bcf_index_build3(dp_out_fname,NULL, BCF_LIDX_SHIFT,n_threads);
   return(0);
 }

--- a/bcftools_plugins/update-info.c
+++ b/bcftools_plugins/update-info.c
@@ -71,7 +71,6 @@ bcf1_t *update_info_fields(bcf1_t *rec,bcf_hdr_t *_in_hdr, bcf_hdr_t *_out_hdr)
 	exit(1);
     }
     int nval=bcf_get_format_int32(_in_hdr, rec, "DP", &f_dp, &ndp);
-    assert(nval==n);
     assert(bcf_get_format_int32(_in_hdr, rec, "AD", &f_ad, &nad)>0);
     int has_pf = bcf_get_format_int32(_in_hdr, rec, "PF", &f_pf, &npf)>0;
     int has_dpf =bcf_get_format_int32(_in_hdr, rec, "DPF", &f_dpf, &ndp)==n;

--- a/hts_utils.h
+++ b/hts_utils.h
@@ -1,0 +1,646 @@
+/* The MIT License
+
+   Copyright (c) 2013 Adrian Tan <atks@umich.edu>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#ifndef HTS_UTILS_H
+#define HTS_UTILS_H
+
+#include <sys/stat.h>
+#include "htslib/kstring.h"
+#include "htslib/khash.h"
+#include "htslib/hts.h"
+#include "htslib/sam.h"
+#include "htslib/vcf.h"
+#include "htslib/bgzf.h"
+#include "htslib/faidx.h"
+#include "htslib/tbx.h"
+#include "htslib/hfile.h"
+#include "utils.h"
+
+/**********
+ *FAI UTILS
+ **********/
+typedef struct {
+    int32_t line_len, line_blen;
+    int64_t len;
+    uint64_t offset;
+} faidx1_t;
+
+KHASH_MAP_INIT_STR(s, faidx1_t)
+
+struct __faidx_t {
+    BGZF *bgzf;
+    int n, m;
+    char **name;
+    khash_t(s) *hash;
+};
+
+/**
+ * An alternate sequence fetcher for upper case sequence.
+ */
+char *faidx_fetch_uc_seq(const faidx_t *fai, const char *c_name, int p_beg_i, int p_end_i, int *len);
+
+/**********
+ *HTS UTILS
+ **********/
+
+/**
+ * Checks file extension for use in writing files.
+ */
+bool str_ends_with(std::string const & value, std::string const & ending);
+
+/**
+ * Checks file extension based on filename.
+ */
+int32_t hts_filename_type(std::string const& value);
+
+/**************
+ *BAM HDR UTILS
+ **************/
+
+/**
+ * Copies contigs found in bam header to bcf header.
+ */
+void bam_hdr_transfer_contigs_to_bcf_hdr(const bam_hdr_t *sh, bcf_hdr_t *vh);
+
+/**
+ * Gets sample names from bam header.
+ */
+std::string bam_hdr_get_sample_name(bam_hdr_t* hdr);
+
+/**
+ * Get number of sequences.
+ */
+#define bam_hdr_get_n_targets(h) ((h)->n_targets)
+
+/**
+ * Get list of sequence names.
+ */
+#define bam_hdr_get_target_name(h) ((h)->target_name)
+
+/**
+ * Get list of sequence lenghts.
+ */
+#define bam_hdr_get_target_len(h) ((h)->target_len)
+
+/**********
+ *BAM UTILS
+ **********/
+
+//used when a base on a read is not aligned to the human genome reference
+//in particular for soft clips and insertions
+#define BAM_READ_INDEX_NA -1
+
+/**
+ * Gets the chromosome name of the tid.
+ */
+#define bam_get_chrom(h, s) ((h)->target_name[(s)->core.tid])
+
+/**
+ * Gets the 1 based start position of the first mapped base in the read.
+ */
+#define bam_get_pos1(s) ((s)->core.pos + 1)
+
+/**
+ * Gets the 0 based start position of the first mapped base in the read.
+ */
+#define bam_get_pos0(s) ((s)->core.pos)
+
+/**
+ * Gets the end position of the last mapped base in the read.
+ */
+int32_t bam_get_end_pos1(bam1_t *srec);
+
+/**
+ * Gets the template ID of the read.
+ */
+#define bam_get_tid(s) ((s)->core.tid)
+
+/**
+ * Gets the template ID of the paired read.
+ */
+#define bam_get_mtid(s) ((s)->core.mtid)
+
+/**
+ * Gets the start position of the first mapped base in the read.
+ */
+#define bam_get_mpos1(s) ((s)->core.mpos)
+
+/**
+ * Gets the read sequence from a bam record
+ */
+void bam_get_seq_string(bam1_t *s, kstring_t *seq);
+
+/**
+ * Gets the base qualities from a bam record.
+ */
+void bam_get_qual_string(bam1_t *s, kstring_t *qual);
+
+/**
+ * Gets the cigar sequence from a bam record.
+ */
+#define bam_get_n_cigar_op(b) ((b)->core.n_cigar)
+
+/**
+ * Gets the cigar from a BAM record.
+ */
+void bam_get_cigar_string(bam1_t *s, kstring_t *cigar);
+
+/**
+ * Gets the cigar string from a bam record.
+ */
+void bam_get_cigar_expanded_string(bam1_t *s, kstring_t *cigar_string);
+
+/**
+ * Is this sequence the first read?
+ */
+#define bam_is_fread1(s) (((s)->core.flag&BAM_FREAD1) != 0)
+
+/**
+ * Is this sequence the second read?
+ */
+#define bam_is_fread2(s) (((s)->core.flag&BAM_FREAD2) != 0)
+
+/**
+ * Gets the base in the read that is mapped to a genomic position.
+ * Returns -1 if it does not exists.
+ */
+void bam_get_base_and_qual(bam1_t *srec, uint32_t pos, char& base, char& qual, int32_t& rpos);
+
+/**
+ * Gets the base in the read that is mapped to a genomic position.
+ * Returns true if successful, false if the location is a deletion or not on the read.
+ */
+void bam_get_base_and_qual_and_read_and_qual(bam1_t *s, uint32_t pos, char& base, char& qual, int32_t& rpos, kstring_t* readseq, kstring_t* readqual);
+
+/**
+ * Converts base encoding to character.
+ */
+#define bam_base2char(b) ("XACXGXXXTXXXXXXN"[(b)])
+
+/**
+ * Gets flag.
+ */
+#define bam_get_flag(s) ((s)->core.flag)
+
+/**
+ * Get map quality.
+ */
+#define bam_get_mapq(s) ((s)->core.qual)
+
+/**
+ * Get tid - e.g. chromosome id.
+ */
+#define bam_get_tid(s) ((s)->core.tid)
+
+/**
+ * Get read length.
+ */
+#define bam_get_l_qseq(s) ((s)->core.l_qseq)
+
+/**
+ * Prints a bam.
+ */
+void bam_print(bam_hdr_t *h, bam1_t *s);
+
+/**************
+ *BCF HDR UTILS
+ **************/
+
+/**
+ * Prints header.
+ */
+void bcf_hdr_print(bcf_hdr_t *h);
+
+/**
+ * Copies contigs found in bcf header to another bcf header.
+ */
+void bcf_hdr_transfer_contigs(const bcf_hdr_t *sh, bcf_hdr_t *vh);
+
+/**
+ * Checks if a particular header type exists
+ * @hdr  - header
+ * @type - BCF_HL_FLT, BCF_HL_INFO, BCF_HL_FMT, BCF_HL_CTG
+ * @key  - the key name
+ */
+bool bcf_hdr_exists(bcf_hdr_t *hdr, int32_t type, const char *key);
+
+/**
+ * Extracts sequence length by rid.
+ */
+int32_t* bcf_hdr_seqlen(const bcf_hdr_t *hdr, int32_t *nseq);
+
+/**
+ * Copies an info fields from one record to another
+ * @hsrc  - source header
+ * @vsrc  - source bcf1_t
+ * @hdest - destination header
+ * @vdest - destination bcf1_t
+ * @type  - BCF_HT_FLAG, BCF_HT_INT, BCF_HT_REAL, BCF_HT_STR
+ * @key   - the key name
+ */
+void bcf_copy_info_field(bcf_hdr_t *hsrc, bcf1_t* vsrc, bcf_hdr_t *hdest, bcf1_t* vdest, const char* key, int32_t type);
+
+/**
+ * Get samples from bcf header
+ */
+#define bcf_hdr_get_samples(h) ((h)->samples)
+
+/**
+ * Get ith sample name from bcf header
+ */
+#define bcf_hdr_get_sample_name(h, i) ((h)->samples[i])
+
+/**
+ * Get number of samples in bcf header
+ */
+int32_t bcf_hdr_get_n_sample(bcf_hdr_t *h);
+
+/**
+ * Reads header of a VCF file and returns the bcf header object.
+ * This wraps around vcf_hdr_read from the original htslib to
+ * allow for an alternative header file to be read in.
+ *
+ * this searches for the alternative header saved as <filename>.hdr
+ * If the VCF files is BCF, any alternative header is ignored.
+ */
+bcf_hdr_t *bcf_alt_hdr_read(htsFile *fp);
+
+/**
+ * Subsets a record by samples.
+ * @imap - indices the subsetted samples
+ */
+int bcf_hdr_subset_samples(const bcf_hdr_t *h, bcf1_t *v, std::vector<int32_t>& imap);
+
+/**
+ * Help function for adding a header with a backup tag name.
+ * If the <tag> is already present, a new tag is attempted
+ * in the format <tag>_1 to <tag>_9.  If <tag>_9 failed,
+ * the function will not add any new tag and will return
+ * an empty string.
+ *
+ * Returns the tag that was inserted or updated.
+ */
+std::string bcf_hdr_append_info_with_backup_naming(bcf_hdr_t *h, std::string tag, std::string number, std::string type, std::string description, bool rename);
+
+/**
+ * Translates BCF_VL types to string.
+ */
+std::string bcf_hdr_vl2str(int32_t id);
+
+/**
+ * Translates BCF_BT types to string.
+ */
+std::string bcf_hdr_ht2str(int32_t id);
+
+/**********
+ *BCF UTILS
+ **********/
+
+/**
+ * Gets number of expected genotypes from number of allelles for a ploidy of 2.
+ */
+#define bcf_an2gn(n) (((n+1)*n)>>1)
+
+/**
+ * Gets number of genotypes from number of alleles and ploidy.
+ *
+ * Returns 0 if number of alleles and genotypes are not consistent.
+ */
+uint32_t bcf_ap2g(uint32_t no_allele, uint32_t no_ploidy);
+
+/**
+ * Gets alleles from number of ploidy and genotype index.
+ */
+void bcf_pg2a(uint32_t no_ploidy, uint32_t genotype_index, std::vector<int32_t>& alleles);
+
+/**
+ * Gets number of ploidy from number of alleles and genotypes.
+ */
+uint32_t bcf_ag2p(uint32_t no_alleles, uint32_t no_genotypes);
+
+/**
+ * Gets genotype from genotype index and ploidy.
+ */
+std::vector<int32_t> bcf_ip2g(int32_t genotype_index, uint32_t no_ploidy);
+
+/**
+ * Gets index of a genotype of p ploidy.
+ */
+uint32_t bcf_g2i(int32_t* g, uint32_t p);
+
+/**
+ * Gets index of a genotype of n ploidy.
+ */
+uint32_t bcf_g2i(std::vector<int32_t>& g);
+
+/**
+ * Gets index of a diploid genotype.
+ */
+#define bcf_2g2c(i,j) ((i)+((((j)+1)*(j))>>1))
+
+///**
+// * Gets number of genotypes from number of alleles and ploidy.
+// */
+//uint32_t bcf_g2i(std::string genotype);
+
+/**
+ * Returns true if a is before b, false otherwise.
+ */
+bool bcf_is_in_order(bcf1_t *a, bcf1_t *b);
+
+/**
+ * Returns a copy v that only has the chr:pos1:ref:alt information.
+ */
+bcf1_t* bcf_copy_variant(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Gets a string representation of a variant.
+ */
+std::string bcf_variant2string(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Gets a string representation of a variant.
+ */
+void bcf_variant2string(bcf_hdr_t *h, bcf1_t *v, kstring_t *var);
+
+/**
+ * Gets a sorted string representation of a variant.
+ */
+void bcf_variant2string_sorted(bcf_hdr_t *h, bcf1_t *v, kstring_t *var);
+
+/**
+ * Gets a string representation of the alleles of a variant.
+ */
+void bcf_alleles2string(bcf_hdr_t *h, bcf1_t *v, kstring_t *var);
+
+/**
+ * Gets a sorted string representation of the alleles of a variant.
+ */
+void bcf_alleles2string_sorted(bcf_hdr_t *h, bcf1_t *v, kstring_t *var);
+
+/**
+ * Prints a VCF record to STDERR.
+ */
+void bcf_print(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Prints a VCF record in compact string representation to STDERR.
+ */
+void bcf_print_lite(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Prints a VCF record in compact string representation to STDERR with alleles sorted.
+ */
+void bcf_print_lite_sorted(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Prints a VCF record in compact string representation to STDERR with a new line.
+ */
+void bcf_print_liten(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Get number of chromosomes
+ */
+#define bcf_get_n_chrom(h) ((h)->n[BCF_DT_CTG])
+
+/**
+ * Get chromosome name
+ */
+const char* bcf_get_chrom(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Set chromosome name
+ */
+void bcf_set_chrom(bcf_hdr_t *h, bcf1_t *v, const char* chrom);
+
+/**
+ * Get RID
+ */
+#define bcf_get_rid(v) ((v)->rid)
+
+/**
+ * Set RID
+ */
+#define bcf_set_rid(v, c) ((v)->rid=(c))
+
+/**
+ * Check if variant is passed
+ */
+bool bcf_is_passed(bcf_hdr_t *h, bcf1_t *v);
+
+/**
+ * Get 0-based position
+ */
+#define bcf_get_pos0(v) ((v)->pos)
+
+/**
+ * Set 0-based position
+ */
+#define bcf_set_pos0(v, p) ((v)->pos = (p))
+
+/**
+ * Get 1-based position
+ */
+#define bcf_get_pos1(v) ((v)->pos+1)
+
+/**
+ * Get 1-based end position
+ */
+#define bcf_get_end1(v) ((v)->pos + strlen((v)->d.allele[0]))
+
+/**
+ * Set 1-based position
+ */
+#define bcf_set_pos1(v, p) ((v)->pos = (p)-1)
+
+/**
+ * Get id
+ */
+#define bcf_get_id(v) ((v)->d.id)
+
+/**
+ * Set id.
+ */
+void bcf_set_id(bcf1_t *v, char* id);
+
+/**
+ * Gets an info flag.
+ */
+bool bcf_get_info_flg(bcf_hdr_t *h, bcf1_t *v, const char* tag);
+
+/**
+ * Sets an info flag.
+ */
+void bcf_set_info_flg(bcf_hdr_t *h, bcf1_t *v, const char* tag, bool value);
+
+/**
+ * Gets an info integer.
+ */
+int32_t bcf_get_info_int(bcf_hdr_t *h, bcf1_t *v, const char* tag, int32_t default_value = 0);
+
+/**
+ * Sets an info integer.
+ */
+void bcf_set_info_int(bcf_hdr_t *h, bcf1_t *v, const char* tag, int32_t value);
+
+/**
+ * Gets an info integer vector.
+ */
+std::vector<int32_t> bcf_get_info_int_vec(bcf_hdr_t *h, bcf1_t *v, const char* tag, int32_t default_size=0, int32_t default_value=0);
+
+/**
+ * Sets an info integer vector.
+ */
+void bcf_set_info_int_vec(bcf_hdr_t *h, bcf1_t *v, const char* tag, std::vector<int32_t>& values);
+
+/**
+ * Gets an info float.
+ */
+float bcf_get_info_flt(bcf_hdr_t *h, bcf1_t *v, const char* tag, float default_value = 0);
+
+/**
+ * Sets an info float.
+ */
+void bcf_set_info_flt(bcf_hdr_t *h, bcf1_t *v, const char* tag, float value);
+
+/**
+ * Gets an info integer vector.
+ */
+std::vector<float> bcf_get_info_flt_vec(bcf_hdr_t *h, bcf1_t *v, const char* tag, int32_t default_size=0, float default_value=0);
+
+/**
+ * Sets an info float vector.
+ */
+void bcf_set_info_flt_vec(bcf_hdr_t *h, bcf1_t *v, const char* tag, std::vector<float>& values);
+
+/**
+ * Gets an info string.
+ */
+std::string bcf_get_info_str(bcf_hdr_t *h, bcf1_t *v, const char* tag, std::string default_value = "");
+
+/**
+ * Sets an info string.
+ */
+void bcf_set_info_str(bcf_hdr_t *h, bcf1_t *v, const char* tag, std::string default_value = "");
+
+/**
+ * Gets an info string vector.
+ */
+std::vector<std::string> bcf_get_info_str_vec(bcf_hdr_t *h, bcf1_t *v, const char* tag, std::string default_value = "");
+
+/**
+ * Sets an info string vector.
+ */
+void bcf_set_info_str_vec(bcf_hdr_t *h, bcf1_t *v, const char* tag, std::vector<std::string> values);
+
+/**
+ * Get allele
+ */
+#define bcf_get_allele(v) ((v)->d.allele)
+
+/**
+ * Get n_alleles of a bcf record
+ */
+#define bcf_get_n_allele(v) ((v)->n_allele)
+
+/**
+ * Get reference base for a SNP, assumes the record is a biallelic SNP
+ */
+#define bcf_get_snp_ref(v) ((v)->d.allele[0][0])
+
+/**
+ * Get alternative base for a SNP, assumes the record is a biallelic SNP
+ */
+#define bcf_get_snp_alt(v) ((v)->d.allele[1][0])
+
+/**
+ * Get reference allele
+ */
+#define bcf_get_ref(v) ((v)->d.allele[0])
+
+/**
+ * Get alternative allele
+ */
+#define bcf_get_alt(v, i) ((v)->d.allele[i])
+
+/**
+ * Get variant type
+ */
+#define bcf_get_var_type(v) ((v)->d.var_type)
+
+/**
+ * Get qual
+ */
+#define bcf_get_qual(v) ((v)->qual)
+
+/**
+ * Get n_flt of a bcf record
+ */
+#define bcf_get_n_filter(v) ((v)->d.n_flt)
+
+/**
+ * Get ith format name
+ */
+#define bcf_get_format(h, v, i) (h)->id[BCF_DT_ID][(v->d.fmt)[i].id].key
+/**
+ * Get number of samples in bcf record
+ */
+#define bcf_get_n_sample(v) ((v)->n_sample)
+
+/**
+ * Set number of samples in bcf record
+ */
+#define bcf_set_n_sample(v, n) ((v)->n_sample = (n))
+
+/**
+ * Get qual
+ */
+#define bcf_get_qual(v) ((v)->qual)
+
+/**
+ * Set qual
+ */
+#define bcf_set_qual(v, q) ((v)->qual = (q))
+
+/**
+ * Creates a dummy header with hs37d5 contigs for testing purposes.
+ */
+bcf_hdr_t* bcf_create_dummy_hdr();
+
+/**
+ * Creates a dummy bcf record representing the variant for testing purposes.
+ *
+ * @variant - 1:123:ACT:AC/ACCCC
+ */
+bcf1_t* bcf_create_dummy_record(bcf_hdr_t* h, std::string& variant);
+
+/**********
+ *LOG UTILS
+ **********/
+
+/**
+ * Gives a notice to STDERR.
+ */
+void notice(const char * msg, ...);
+
+#endif

--- a/make_chunk.py
+++ b/make_chunk.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     ##collate chunks with multiprocessing pool
     def process_gvcf(f):        
         tmp_out = "%s/%s"%(tmp_dir,os.path.basename(f).split(".")[0])
-        cmd = args.agg + " ingest1 " + f + " -o " + tmp_out + " -f " + args.ref
+        cmd = args.agg + " ingest1 '" + f + "' -o " + tmp_out + " -f " + args.ref
         if args.ignore_non_matching_ref:
             cmd += " --ignore-non-matching-ref"
         sys.stderr.write(cmd+"\n")

--- a/make_chunk.py
+++ b/make_chunk.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
         cmd = args.agg + " ingest1 '" + f + "' -o " + tmp_out + " -f " + args.ref
         if args.ignore_non_matching_ref:
             cmd += " --ignore-non-matching-ref"
+        cmd += " > %s.log"%tmp_out
         sys.stderr.write(cmd+"\n")
         try:
             cmd_output = subprocess.check_output(cmd,shell=True)

--- a/needle.cpp
+++ b/needle.cpp
@@ -1,0 +1,180 @@
+/* The MIT License
+
+   Copyright (c) 2015 Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "needle.h"
+
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+NeedlemanWunsch::NeedlemanWunsch(bool debug)
+{
+    this->debug = debug;
+}
+
+void NeedlemanWunsch::align(const char* ref, const char* read)
+{
+    this->ref = ref;
+    this->read = read;
+    this->len_ref = strlen(ref);
+    this->len_read = strlen(read);
+
+    matrix.clear();
+    matrix.resize((len_ref + 1) * (len_read + 1), EMPTY);
+
+    // fill first column and row
+    scores.resize(len_read + 1);
+    for (unsigned i = 0; i <= len_ref; ++i)
+        matrix.at(i * (len_read + 1)) = CIGAR_D;
+    for (unsigned i = 0; i <= len_read; ++i)
+    {
+        matrix.at(i) = CIGAR_I;
+        scores.at(i) = i * params.score_gap;
+    }
+    matrix.at(0) = CIGAR_M;
+
+    // fill remainder of the matrix
+    int offset = 0;
+    int score_n = 0;
+    for (unsigned i = 1; i <= len_ref; ++i)
+    {
+        offset += len_read + 1;
+        score_n += params.score_gap;
+        int best_score = 0;
+        for (unsigned j = 1; j <= len_read; ++j)
+        {
+            int score_nw = scores.at(j - 1);
+            int score_w = scores.at(j);
+
+            int score_diag = score_nw;
+            Traceback best_dir;
+            if (ref[i - 1] == read[j - 1])
+            {
+                best_dir = CIGAR_M;
+                score_diag += params.score_match;
+            }
+            else
+            {
+                best_dir = CIGAR_X;
+                score_diag += params.score_mismatch;
+            }
+
+            best_score = score_diag;
+
+            if (score_w + params.score_gap > best_score)
+            {
+                best_score = score_w + params.score_gap;
+                best_dir = CIGAR_D;
+            }
+            else if (score_n + params.score_gap > best_score)
+            {
+                best_score = score_n + params.score_gap;
+                best_dir = CIGAR_I;
+            }
+
+            scores.at(j - 1) = score_n;
+            score_n = best_score;
+            matrix.at(offset + j) = best_dir;
+        }
+        scores.back() = best_score;
+    }
+
+}
+
+void NeedlemanWunsch::trace_path()
+{
+    int i = len_ref;
+    int j = len_read;
+    int k = (len_read + 1) * (len_ref + 1) - 1;
+
+    trace.clear();
+
+    while (i>0 || j>0)
+    {
+        trace.push_back(matrix.at(k));
+        switch ((int32_t) matrix.at(k))
+        {
+            case CIGAR_X:
+            case CIGAR_M:
+                --i;
+                --j;
+                k -= len_read + 2;
+                break;
+            case CIGAR_I:
+                --j;
+                --k;
+                break;
+            case CIGAR_D:
+                --i;
+                k -= len_read + 1;
+                break;
+        }
+    }
+
+    std::reverse(trace.begin(), trace.end());
+}
+
+void NeedlemanWunsch::print_alignment(std::string const & pad)
+{
+    // print reference
+    std::cerr << pad;
+    for (unsigned i = 0, j = 0; i < trace.size(); ++i)
+    {
+        if (trace.at(i) == CIGAR_X || trace[i] == CIGAR_M || trace.at(i) == CIGAR_D)
+            std::cerr << ref[j++];
+        else
+            std::cerr << "-";
+    }
+    std::cerr << "\n";
+
+    // print trace
+    std::cerr << pad;
+    for (unsigned i = 0, j = 0, k = 0; i < trace.size(); ++i)
+    {
+        if (trace[i] == CIGAR_X || trace[i] == CIGAR_M)
+            std::cerr << ((ref[j++] == read[k++]) ? '|' : ' ');
+        else if (trace[i] == CIGAR_D)
+        {
+            j++;
+            std::cerr << " ";
+        }
+        else  // trace[i] == CIGAR_I
+        {
+            k++;
+            std::cerr << " ";
+        }
+    }
+    std::cerr << "\n";
+
+    // print read
+    std::cerr << pad;
+    for (unsigned i = 0, j = 0; i < trace.size(); ++i)
+    {
+        if (trace[i] == CIGAR_X || trace[i] == CIGAR_M || trace[i] == CIGAR_I)
+            std::cerr << read[j++];
+        else
+            std::cerr << "-";
+    }
+    std::cerr << "\n";
+}

--- a/needle.h
+++ b/needle.h
@@ -1,0 +1,94 @@
+/* The MIT License
+
+   Copyright (c) 2015 Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+#ifndef NEEDLE_H
+#define NEEDLE_H
+
+#include "utils.h"
+
+class NWParameters
+{
+    public:
+
+    int score_match;
+    int score_mismatch;
+    int score_gap;
+
+    NWParameters() : score_match(0), score_mismatch(-1), score_gap(-1)
+    {}
+};
+
+class NeedlemanWunsch
+{
+    public:
+
+    // in CIGAR: "?", "D", "M", "X", "I"
+    enum Traceback { EMPTY, CIGAR_D, CIGAR_M, CIGAR_X, CIGAR_I };
+
+    bool debug;
+    const char* ref;
+    const char* read;
+
+    int len_ref;
+    int len_read;
+
+    std::vector<int> scores;
+    std::vector<Traceback> matrix;
+    std::vector<Traceback> trace;
+
+    NWParameters params;
+
+    /**
+     * Constructor.
+     */
+    NeedlemanWunsch(bool debug=false);
+
+    void set_read(const char * read) 
+    {
+        this->read = read;
+    }
+
+    /**
+     * Align and compute genotype likelihood.
+     */
+    void align(const char* ref, const char* read);
+
+    /**
+     * Trace path after alignment and write to trace.
+     */
+    void trace_path();
+
+    /**
+     * Prints an alignment.
+     */
+    void print_alignment()
+    {
+        print_alignment("");
+    }
+
+    /**
+     * Prints an alignment with padding.
+     */
+    void print_alignment(std::string const & pad);
+};
+
+#endif  // ifndef NEEDLE_H


### PR DESCRIPTION
* the complex substitution decomposition taken from (vt)[https://github.com/atks/vt] is now applied on gvcf import
* `FORMAT/AD` will not be populated from homozygous reference blocks (note that this is still a lossy measure)
* switch to htslib-1.4
